### PR TITLE
Update red-sdl-bindings.reds

### DIFF
--- a/red-sdl-bindings.reds
+++ b/red-sdl-bindings.reds
@@ -323,10 +323,10 @@ Red/System []
 ] 
 
 sdl-rect!: alias struct! [
- 	h 	[integer!]
- 	w 	[integer!]
  	x 	[integer!]
-	y 	[integer!]
+ 	y 	[integer!]
+ 	w 	[integer!]
+	h 	[integer!]
 ]
 
 sdl-color!: alias struct! [


### PR DESCRIPTION
The fields of SDL-rect! were mixed up. The example lesson05.reds should work now.