### PR TITLE
Fix for compile bug

### DIFF
--- a/red-sdl-bindings.reds
+++ b/red-sdl-bindings.reds
@@ -617,7 +617,7 @@ sdl-event!: alias struct! [
 
 
 ;probe direct-3d
-main: func [return: [integer!] /local event direct-3d keyboard] [
+main: func [return: [integer!] /local event direct-3d keyboard width height direct-3d-device] [
 	width:              800
 	height:             480
 	event:              declare sdl-event!


### PR DESCRIPTION
Localized some uncaptured variables causing compiling to fail in red 0.6.3